### PR TITLE
Job ReferenceReplacementJob is obsolete, Replacing it with running pipeline "replaceItemReferences", also creating helper method to update links when creating items of branch templates

### DIFF
--- a/src/Sitecore.SmartCommands.UnitTests/App.config
+++ b/src/Sitecore.SmartCommands.UnitTests/App.config
@@ -1,44 +1,44 @@
-﻿<configuration>
+<configuration>
   <configSections>
-    <section name="sitecore" type="Sitecore.FakeDb.Configuration.ConfigReader, Sitecore.FakeDb" />
-    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, Sitecore.Logging" />
+    <section name="sitecore" type="Sitecore.FakeDb.Configuration.ConfigReader, Sitecore.FakeDb"/>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, Sitecore.Logging"/>
   </configSections>
   <appSettings>
-    <add key="xunit.parallelizeTestCollections" value="false" />
+    <add key="xunit.parallelizeTestCollections" value="false"/>
   </appSettings>
   <sitecore>
     <settings>
-      <setting name="LicenseFile" value="C:\Sitecore\Licenses\License.xml" />
+      <setting name="LicenseFile" value="C:\Sitecore\Licenses\License.xml"/>
     </settings>
     <!-- DATABASE TYPE
          For Sitecore versions prior to 8.2 should be 'Sitecore.Data.Database, Sitecore.Kernel'.
          For Sitecore 8.2 and later should be 'Sitecore.Data.DefaultDatabase, Sitecore.Kernel'. -->
-    <sc.variable name="databaseType" value="Sitecore.Data.Database, Sitecore.Kernel" />
+    <sc.variable name="databaseType" value="Sitecore.Data.Database, Sitecore.Kernel"/>
   </sitecore>
-  <log4net />
+  <log4net/>
   <system.web>
     <membership defaultProvider="fake">
       <providers>
-        <clear />
-        <add name="fake" type="Sitecore.FakeDb.Security.Web.FakeMembershipProvider, Sitecore.FakeDb" />
+        <clear/>
+        <add name="fake" type="Sitecore.FakeDb.Security.Web.FakeMembershipProvider, Sitecore.FakeDb"/>
       </providers>
     </membership>
     <roleManager defaultProvider="fake" enabled="true">
       <providers>
-        <clear />
-        <add name="fake" type="Sitecore.FakeDb.Security.Web.FakeRoleProvider, Sitecore.FakeDb" />
+        <clear/>
+        <add name="fake" type="Sitecore.FakeDb.Security.Web.FakeRoleProvider, Sitecore.FakeDb"/>
       </providers>
     </roleManager>
     <profile defaultProvider="fake" enabled="true" inherits="Sitecore.FakeDb.Profile.FakeUserProfile, Sitecore.FakeDb">
       <providers>
-        <clear />
-        <add name="fake" type="Sitecore.FakeDb.Security.Web.FakeProfileProvider, Sitecore.FakeDb" />
+        <clear/>
+        <add name="fake" type="Sitecore.FakeDb.Security.Web.FakeProfileProvider, Sitecore.FakeDb"/>
       </providers>
       <properties>
-        <clear />
-        <add type="System.String" name="SC_UserData" />
+        <clear/>
+        <add type="System.String" name="SC_UserData"/>
       </properties>
     </profile>
   </system.web>
   
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>

--- a/src/Sitecore.SmartCommands.UnitTests/Sitecore.SmartCommands.UnitTests.csproj
+++ b/src/Sitecore.SmartCommands.UnitTests/Sitecore.SmartCommands.UnitTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.SmartCommands.UnitTests</RootNamespace>
     <AssemblyName>Sitecore.SmartCommands.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,24 +44,28 @@
       <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
-      <HintPath>..\packages\SC.Lucene.Net.8.1.3\lib\Lucene.Net.dll</HintPath>
+      <HintPath>..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Sitecore.FakeDb, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sitecore.FakeDb.1.4.1\lib\net45\Sitecore.FakeDb.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SC.Sitecore.Kernel.8.1.3\lib\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.170728\lib\NET452\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.Logging, Version=1.2.0.30715, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SC.Sitecore.Logging.8.1.3\lib\Sitecore.Logging.dll</HintPath>
+    <Reference Include="Sitecore.Logging, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Logging.NoReferences.8.2.170728\lib\NET452\Sitecore.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="sitecore.nexus, Version=1.0.0.4407, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SC.sitecore.nexus.8.1.3\lib\sitecore.nexus.dll</HintPath>
+    <Reference Include="Sitecore.Nexus, Version=1.0.4430.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Nexus.NoReferences.8.2.170728\lib\NET452\Sitecore.Nexus.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Sitecore.SmartCommands.UnitTests/packages.config
+++ b/src/Sitecore.SmartCommands.UnitTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.18.0" targetFramework="net45" />
-  <package id="SC.Lucene.Net" version="8.1.3" targetFramework="net45" />
-  <package id="SC.Sitecore.Kernel" version="8.1.3" targetFramework="net45" />
-  <package id="SC.Sitecore.Logging" version="8.1.3" targetFramework="net45" />
-  <package id="SC.sitecore.nexus" version="8.1.3" targetFramework="net45" />
-  <package id="Sitecore.FakeDb" version="1.4.1" targetFramework="net45" />
+  <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.170728" targetFramework="net461" developmentDependency="true" />
+  <package id="Sitecore.Logging.NoReferences" version="8.2.170728" targetFramework="net461" developmentDependency="true" />
+  <package id="Sitecore.Nexus.NoReferences" version="8.2.170728" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/src/Sitecore.SmartCommands/Events/ItemAdded/UpdateLinks.cs
+++ b/src/Sitecore.SmartCommands/Events/ItemAdded/UpdateLinks.cs
@@ -1,55 +1,46 @@
 ﻿namespace Sitecore.SmartCommands.Events.ItemAdded
 {
-  using System;
-  using Sitecore.Data.Items;
-  using Sitecore.Diagnostics;
-  using Sitecore.Events;
-  using Sitecore.Jobs;
-  using Sitecore.StringExtensions;
+    using System;
+    using Sitecore.Data.Items;
+    using Sitecore.Diagnostics;
+    using Sitecore.Events;
+    using Sitecore.Jobs;
+    using Sitecore.StringExtensions;
 
-  public class UpdateLinks
-  {
-    private readonly bool isAsync;
-
-    public UpdateLinks()
+    public class UpdateLinks
     {
-      this.isAsync = false;
+        private readonly bool isAsync;
+
+        public UpdateLinks()
+        {
+            this.isAsync = false;
+        }
+
+        public UpdateLinks([NotNull] string async)
+        {
+            Assert.ArgumentNotNull(async, "async");
+
+            this.isAsync = string.Equals(async, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        [UsedImplicitly]
+        public void OnItemAdded([CanBeNull] object sender, [NotNull] EventArgs args)
+        {
+            Assert.ArgumentNotNull(args, "args");
+
+            var contentItem = Event.ExtractParameter(args, 0) as Item;
+            Assert.IsNotNull(contentItem, "targetItem");
+
+            var branchItem = contentItem.Branch;
+            if (branchItem == null)
+            {
+                return;
+            }
+
+            var item = branchItem.InnerItem;
+            Assert.IsTrue(item.Children.Count == 1, "branch item structure is corrupted: {0}".FormatWith(AuditFormatter.FormatItem(item)));
+
+            Helper.RelinkDatasourcesInBranchInstance(contentItem, true);
+        }
     }
-
-    public UpdateLinks([NotNull] string async)
-    {
-      Assert.ArgumentNotNull(async, "async");
-
-      this.isAsync = string.Equals(async, "true", StringComparison.OrdinalIgnoreCase);
-    }
-
-    [UsedImplicitly]
-    public void OnItemAdded([CanBeNull] object sender, [NotNull] EventArgs args)
-    {
-      Assert.ArgumentNotNull(args, "args");
-
-      var contentItem = Event.ExtractParameter(args, 0) as Item;
-      Assert.IsNotNull(contentItem, "targetItem");
-
-      var branchItem = contentItem.Branch;
-      if (branchItem == null)
-      {
-        return;
-      }
-
-      var item = branchItem.InnerItem;
-      Assert.IsTrue(item.Children.Count == 1, "branch item structure is corrupted: {0}".FormatWith(AuditFormatter.FormatItem(item)));
-
-
-      var branch = item.Children[0];
-      if (this.isAsync)
-      {
-        ReferenceReplacementJob.StartAsync(branch, contentItem);
-      }
-      else
-      {
-        ReferenceReplacementJob.Start(branch, contentItem);
-      }
-    }
-  }
 }

--- a/src/Sitecore.SmartCommands/Helper.cs
+++ b/src/Sitecore.SmartCommands/Helper.cs
@@ -1,0 +1,212 @@
+﻿using Sitecore;
+using Sitecore.Data;
+using Sitecore.Data.Fields;
+using Sitecore.Data.Items;
+using Sitecore.Diagnostics;
+using Sitecore.Layouts;
+using Sitecore.SecurityModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace Sitecore.SmartCommands
+{
+    public static class Helper
+    {
+        /// <summary>
+        /// Replace item references (Datasource links) with new ones that are descendant of it
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="copy"></param>
+        /// <param name="deep"></param>
+        /// <param name="isAsync"></param>
+        public static void ReplaceItemReferences(Item source, Item copy, bool deep, bool isAsync)
+        {
+            Sitecore.Pipelines.CorePipeline.Run("replaceItemReferences", new Sitecore.Pipelines.ReplaceItemReferences.ReplaceItemReferencesArgs()
+            {
+                SourceItem = source,
+                CopyItem = copy,
+                Deep = deep,
+                Async = isAsync
+            });
+        }
+
+        /// <summary>
+        /// Utility method for relinking branch datasources
+        /// </summary>
+        public static void RelinkDatasourcesInBranchInstance(Item item, bool descendants = false)
+        {
+            RelinkDatasourcesForItemInBranchInstance(item, item);
+
+            if (!descendants)
+            {
+                return;
+            }
+
+            foreach (var descendant in item.Axes.GetDescendants())
+            {
+                RelinkDatasourcesForItemInBranchInstance(descendant, item);
+            }
+        }
+
+        /// <summary>
+        /// Utility method for relinking datasources for an item within a branch instance
+        /// </summary>
+        /// <remarks>
+        /// Adapted from original code, written by Kam Figy: 
+        /// https://github.com/kamsar/BranchPresets/blob/master/BranchPresets/AddFromBranchPreset.cs
+        /// </remarks>
+        public static void RelinkDatasourcesForItemInBranchInstance(Item item, Item instanceRoot)
+        {
+            Action<RenderingDefinition> relinkRenderingDatasource =
+                rendering =>
+                    RelinkRenderingDatasourceForItemInBranch(item, instanceRoot, rendering);
+
+            ApplyActionToAllRenderings(item, relinkRenderingDatasource);
+        }
+
+
+        /// <summary>
+        /// Utility method for relinking the datasource for the supplied rendering on an item in the branch instance
+        /// </summary>
+        /// <remarks>
+        /// Adapted from original code, written by Kam Figy: 
+        /// https://github.com/kamsar/BranchPresets/blob/master/BranchPresets/AddFromBranchPreset.cs
+        /// </remarks>
+        /// <param name="item">Item that contains the rendering</param>
+        /// <param name="instanceRoot">Root item of the branch instance</param>
+        /// <param name="rendering">Rendering to be relinked</param>
+        public static void RelinkRenderingDatasourceForItemInBranch(Item item, Item instanceRoot, RenderingDefinition rendering)
+        {
+            var branchBasePath = item.Branch.InnerItem.Paths.FullPath;
+
+            if (string.IsNullOrWhiteSpace(rendering.Datasource))
+            {
+                return;
+            }
+
+            var database = item.Database;
+
+            // note: queries and multiple item datasources are not supported
+            var renderingTargetItem = database.GetItem(rendering.Datasource);
+
+            Assert.IsNotNull(
+                renderingTargetItem,
+                String.Format("Error while expanding branch template rendering datasources: data source {0} was not resolvable.", rendering.Datasource)
+                    );
+
+            // if there was no valid target item OR the target item is not a child of the branch template we skip out
+            if (renderingTargetItem == null ||
+                !renderingTargetItem.Paths.FullPath.StartsWith(branchBasePath, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            // get the path relative to the branch item
+            var relativeRenderingPath =
+                renderingTargetItem.Paths.FullPath.Substring(branchBasePath.Length);
+
+            // replace $name Sitecore tokens in path
+            relativeRenderingPath = relativeRenderingPath
+                .Replace("$name", instanceRoot.Name);
+
+            var newTargetPath = instanceRoot.Parent.Paths.FullPath + relativeRenderingPath;
+            var newTargetItem = database.GetItem(newTargetPath);
+
+            // if the target item was a valid under branch item, but the same relative path does not exist under the branch instance
+            // we set the datasource to something invalid to avoid any potential unintentional edits of a shared data source item
+            rendering.Datasource = newTargetItem?.ID.ToString() ?? "INVALID_BRANCH_SUBITEM_ID";
+        }
+
+        /// <summary>
+        ///     Invokes Action on all Renderings on item
+        /// </summary>
+        public static void ApplyActionToAllRenderings(Item item, Action<RenderingDefinition> action)
+        {
+            ApplyActionToAllSharedRenderings(item, action);
+            ApplyActionToAllFinalRenderings(item, action);
+        }
+
+        /// <summary>
+        ///     Invokes Action on all Shared Renderings on item
+        /// </summary>
+        public static void ApplyActionToAllSharedRenderings(Item item, Action<RenderingDefinition> action)
+        {
+            ApplyActionToLayoutField(item, FieldIDs.LayoutField, action);
+        }
+
+        /// <summary>
+        ///     Invokes Action on all Final Renderings on item
+        /// </summary>
+        public static void ApplyActionToAllFinalRenderings(Item item, Action<RenderingDefinition> action)
+        {
+            ApplyActionToLayoutField(item, FieldIDs.FinalLayoutField, action);
+        }
+
+        /// <summary>
+        ///     Invokes Action on all Final Renderings on item
+        /// </summary>
+        private static void ApplyActionToLayoutField(Item item, ID fieldId, Action<RenderingDefinition> action)
+        {
+            var currentLayoutXml = LayoutField.GetFieldValue(item.Fields[fieldId]);
+            if (string.IsNullOrEmpty(currentLayoutXml))
+            {
+                return;
+            }
+
+            var newXml = ApplyActionToLayoutXml(currentLayoutXml, action);
+            if (newXml == null)
+            {
+                return;
+            }
+
+            using (new SecurityDisabler())
+            {
+                using (new EditContext(item))
+                {
+                    // NOTE: when dealing with layouts its important to get and set the field value with LayoutField.Get/SetFieldValue()
+                    // if you fail to do this you will not process layout deltas correctly and may instead override all fields (breaking full inheritance), 
+                    // or attempt to get the layout definition for a delta value, which will result in your wiping the layout details when they get saved.
+                    LayoutField.SetFieldValue(item.Fields[fieldId], newXml);
+                }
+            }
+        }
+
+        private static string ApplyActionToLayoutXml(string xml, Action<RenderingDefinition> action)
+        {
+            var layout = LayoutDefinition.Parse(xml);
+
+            // normalize the output in case of any minor XML differences (spaces, etc)
+            xml = layout.ToXml();
+
+            // loop over devices in the rendering
+            for (var deviceIndex = layout.Devices.Count - 1; deviceIndex >= 0; deviceIndex--)
+            {
+                var device = layout.Devices[deviceIndex] as DeviceDefinition;
+                if (device == null)
+                {
+                    continue;
+                }
+
+                // loop over renderings within the device
+                for (var renderingIndex = device.Renderings.Count - 1; renderingIndex >= 0; renderingIndex--)
+                {
+                    var rendering = device.Renderings[renderingIndex] as RenderingDefinition;
+                    if (rendering == null)
+                    {
+                        continue;
+                    }
+
+                    // run the action on the rendering
+                    action(rendering);
+                }
+            }
+
+            var layoutXml = layout.ToXml();
+
+            // save a modified layout value if necessary
+            return layoutXml != xml ? layoutXml : null;
+        }
+    }
+}

--- a/src/Sitecore.SmartCommands/Pipelines/CloneItems/UpdateLinks.cs
+++ b/src/Sitecore.SmartCommands/Pipelines/CloneItems/UpdateLinks.cs
@@ -24,34 +24,27 @@
     [UsedImplicitly]
     public void Process([NotNull] CopyItemsArgs args)
     {
-      Assert.ArgumentNotNull(args, "args");
+            Assert.ArgumentNotNull(args, "args");
 
-      var parameters = args.Parameters;
-      Assert.IsNotNull(parameters, "parameters");
+            var parameters = args.Parameters;
+            Assert.IsNotNull(parameters, "parameters");
 
-      if (!string.Equals(parameters["mode"], "smart", StringComparison.OrdinalIgnoreCase))
-      {
-        return;
-      }
+            if (!string.Equals(parameters["mode"], "smart", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
 
 
-      var copies = args.Copies;
-      Assert.IsNotNull(copies, "copies");
+            var copies = args.Copies;
+            Assert.IsNotNull(copies, "copies");
 
-      foreach (var copy in copies)
-      {
-        if (this.isAsync)
-        {
-          ReferenceReplacementJob.StartAsync(copy.Source, copy);
+            foreach (var copy in copies)
+            {
+                Helper.ReplaceItemReferences(copy.Source, copy, true, isAsync);
+            }
+
+            // if mode is smart then this should be the last processor
+            args.AbortPipeline();
         }
-        else
-        {
-          ReferenceReplacementJob.Start(copy.Source, copy);
-        }
-      }
-
-      // if mode is smart then this should be the last processor
-      args.AbortPipeline();
-    }
   }
 }

--- a/src/Sitecore.SmartCommands/Pipelines/CopyItems/UpdateLinks.cs
+++ b/src/Sitecore.SmartCommands/Pipelines/CopyItems/UpdateLinks.cs
@@ -1,81 +1,74 @@
 ﻿namespace Sitecore.SmartCommands.Pipelines.CopyItems
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Linq;
-  using Sitecore.Configuration;
-  using Sitecore.Data.Items;
-  using Sitecore.Diagnostics;
-  using Sitecore.Shell.Framework.Pipelines;
-  using Sitecore.Jobs;
-  using Sitecore.Text;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Sitecore.Configuration;
+    using Sitecore.Data.Items;
+    using Sitecore.Diagnostics;
+    using Sitecore.Shell.Framework.Pipelines;
+    using Sitecore.Jobs;
+    using Sitecore.Text;
 
-  public sealed class UpdateLinks
-  {
-    private readonly bool isAsync;
-
-    public UpdateLinks()
+    public sealed class UpdateLinks
     {
-      this.isAsync = false;
-    }
+        private readonly bool isAsync;
 
-    public UpdateLinks([NotNull] string async)
-    {
-      Assert.ArgumentNotNull(async, "async");
-
-      this.isAsync = string.Equals(async, "true", StringComparison.OrdinalIgnoreCase);
-    }
-
-    [UsedImplicitly]
-    public void Process([NotNull] CopyItemsArgs args)
-    {
-      Assert.ArgumentNotNull(args, "args");
-
-      var parameters = args.Parameters;
-      Assert.IsNotNull(parameters, "parameters");
-
-      if (!string.Equals(parameters["mode"], "smart", StringComparison.OrdinalIgnoreCase))
-      {
-        return;
-      }
-      
-      var copies = args.Copies;
-      Assert.IsNotNull(copies, "copies");
-
-      var sources = GetItems(args).ToArray();
-      for (var i = 0; i < copies.Length; i++)
-      {
-        var copy = copies[i];
-        var source = sources[i];
-        if (this.isAsync)
+        public UpdateLinks()
         {
-          ReferenceReplacementJob.StartAsync(source, copy);
+            this.isAsync = false;
         }
-        else
+
+        public UpdateLinks([NotNull] string async)
         {
-          ReferenceReplacementJob.Start(source, copy);
+            Assert.ArgumentNotNull(async, "async");
+
+            this.isAsync = string.Equals(async, "true", StringComparison.OrdinalIgnoreCase);
         }
-      }
 
-      // if mode is smart then this should be the last processor
-      args.AbortPipeline();
-    }
-
-    private static IEnumerable<Item> GetItems(CopyItemsArgs args)
-    {
-      var databaseName = args.Parameters["database"];
-      var database = Factory.GetDatabase(databaseName);
-      Assert.IsNotNull(database, "database");
-
-      var listString = new ListString(args.Parameters["items"], '|');
-      foreach (var idString in listString)
-      {
-        var item = database.GetItem(idString);
-        if (item != null)
+        [UsedImplicitly]
+        public void Process([NotNull] CopyItemsArgs args)
         {
-          yield return item;
+            Assert.ArgumentNotNull(args, "args");
+
+            var parameters = args.Parameters;
+            Assert.IsNotNull(parameters, "parameters");
+
+            if (!string.Equals(parameters["mode"], "smart", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var copies = args.Copies;
+            Assert.IsNotNull(copies, "copies");
+
+            var sources = GetItems(args).ToArray();
+            for (var i = 0; i < copies.Length; i++)
+            {
+                var copy = copies[i];
+                var source = sources[i];
+                Helper.ReplaceItemReferences(source, copy, true, isAsync);
+            }
+
+            // if mode is smart then this should be the last processor
+            args.AbortPipeline();
         }
-      }
+
+        private static IEnumerable<Item> GetItems(CopyItemsArgs args)
+        {
+            var databaseName = args.Parameters["database"];
+            var database = Factory.GetDatabase(databaseName);
+            Assert.IsNotNull(database, "database");
+
+            var listString = new ListString(args.Parameters["items"], '|');
+            foreach (var idString in listString)
+            {
+                var item = database.GetItem(idString);
+                if (item != null)
+                {
+                    yield return item;
+                }
+            }
+        }
     }
-  }
 }

--- a/src/Sitecore.SmartCommands/Pipelines/DuplicateItem/UpdateLinks.cs
+++ b/src/Sitecore.SmartCommands/Pipelines/DuplicateItem/UpdateLinks.cs
@@ -1,61 +1,57 @@
 ﻿namespace Sitecore.SmartCommands.Pipelines.DuplicateItem
 {
-  using System;
-  using Sitecore.Configuration;
-  using Sitecore.Diagnostics;
-  using Sitecore.Jobs;
-  using Sitecore.Web.UI.Sheer;
+    using System;
+    using Sitecore.Configuration;
+    using Sitecore.Diagnostics;
+    using Sitecore.Jobs;
+    using Sitecore.Web.UI.Sheer;
 
-  public sealed class UpdateLinks
-  {
-    private readonly bool isAsync;
-
-    public UpdateLinks()
+    public sealed class UpdateLinks
     {
-      this.isAsync = false;
+        private readonly bool isAsync;
+
+        public UpdateLinks()
+        {
+            this.isAsync = false;
+        }
+
+        public UpdateLinks([NotNull] string async)
+        {
+            Assert.ArgumentNotNull(async, "async");
+
+            this.isAsync = string.Equals(async, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        [UsedImplicitly]
+        public void Process([NotNull] ClientPipelineArgs args)
+        {
+            Assert.ArgumentNotNull(args, "args");
+
+            var parameters = args.Parameters;
+            Assert.IsNotNull(parameters, "parameters");
+
+            if (!string.Equals(parameters["mode"], "smart", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var databaseName = parameters["database"];
+            var database = Factory.GetDatabase(databaseName);
+            Assert.IsNotNull(database, "database");
+
+            var copyId = parameters["copyId"];
+            var copyItem = database.GetItem(copyId);
+            Assert.IsNotNull(copyId, "copyId");
+
+            var sourceId = parameters["id"];
+            var sourceItem = database.GetItem(sourceId);
+            Assert.IsNotNull(sourceId, "sourceId");
+
+            Helper.ReplaceItemReferences(sourceItem, copyItem, true, isAsync);
+
+
+            // if mode is smart then this should be the last processor
+            args.AbortPipeline();
+        }
     }
-
-    public UpdateLinks([NotNull] string async)
-    {
-      Assert.ArgumentNotNull(async, "async");
-
-      this.isAsync = string.Equals(async, "true", StringComparison.OrdinalIgnoreCase);
-    }
-
-    [UsedImplicitly]
-    public void Process([NotNull] ClientPipelineArgs args)
-    {
-      Assert.ArgumentNotNull(args, "args");
-
-      var parameters = args.Parameters;
-      Assert.IsNotNull(parameters, "parameters");
-
-      if (!string.Equals(parameters["mode"], "smart", StringComparison.OrdinalIgnoreCase))
-      {
-        return;
-      }
-
-      var databaseName = parameters["database"];
-      var database = Factory.GetDatabase(databaseName);
-      Assert.IsNotNull(database, "database");
-
-      var copyId = parameters["copyId"];
-      Assert.IsNotNull(copyId, "copyId");
-
-      var sourceId = parameters["id"];
-      Assert.IsNotNull(sourceId, "sourceId");
-
-      if (this.isAsync)
-      {
-        ReferenceReplacementJob.StartAsync(database, sourceId, copyId);
-      }
-      else
-      {
-        ReferenceReplacementJob.Start(database, sourceId, copyId);
-      }
-
-      // if mode is smart then this should be the last processor
-      args.AbortPipeline();
-    }
-  }
 }

--- a/src/Sitecore.SmartCommands/Sitecore.SmartCommands.csproj
+++ b/src/Sitecore.SmartCommands/Sitecore.SmartCommands.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.SmartCommands</RootNamespace>
     <AssemblyName>Sitecore.SmartCommands</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -48,16 +48,23 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SC.Sitecore.Kernel.8.1.3\lib\Sitecore.Kernel.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.170728\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Events\ItemAdded\UpdateLinks.cs" />
+    <Compile Include="Helper.cs" />
     <Compile Include="Pipelines\CopyItems\UpdateLinks.cs" />
     <Compile Include="Pipelines\CloneItems\UpdateLinks.cs" />
     <Compile Include="Pipelines\DuplicateItem\Execute.cs" />
@@ -74,7 +81,10 @@
     <Content Include="App_Config\Include\Sitecore.SmartCommands.CreateFromBranch.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+    <Content Include="web.config" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Sitecore.SmartCommands/packages.config
+++ b/src/Sitecore.SmartCommands/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SC.Sitecore.Kernel" version="8.1.3" targetFramework="net45" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.170728" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/src/Sitecore.SmartCommands/web.config
+++ b/src/Sitecore.SmartCommands/web.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0"?>
+<configuration>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.6.1" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation debug="true" targetFramework="4.6.1"/>
+    <httpRuntime targetFramework="4.5"/>
+  </system.web>
+</configuration>


### PR DESCRIPTION
Job ReferenceReplacementJob is obsolete, Replacing it with running pipeline "replaceItemReferences", also creating helper method to update links when creating items of branch templates
